### PR TITLE
Fix Google Analytics template override for Furo docs

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,4 +1,4 @@
-{% extends "!layout.html" %}
+{% extends "!base.html" %}
 {% block extrahead %}
     {{ super() }}
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-86MD3VSW50"></script>


### PR DESCRIPTION
### Motivation
- The Furo Sphinx theme does not support inheriting from `layout.html`, so the existing Google Analytics snippet placed in `docs/_templates/layout.html` was ignored and never emitted into built pages.

### Description
- Rename the custom template to `docs/_templates/base.html` and change the parent template to extend `!base.html` so Furo will accept the override and render it.
- Insert the existing Google Analytics `gtag` snippet into the `extrahead` block while preserving upstream head content via `{{ super() }}`.

### Testing
- Built the site successfully with `python -m uv run sphinx-build -b dirhtml docs docs/_build/dirhtml` and the build completed without errors.
- Verified the analytics snippet is present in the generated HTML using `rg -n "G-86MD3VSW50|googletagmanager|gtag" docs/_build/dirhtml/index.html` which returned matches.
- Attempted `curl` against the live site but DNS resolution failed, so validation was performed against the locally generated output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c04c83488326b15119245302cf75)